### PR TITLE
Updated CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(youbot_driver)
+# to compile in Windows
+set(Boost_USE_STATIC_LIBS ON)
 
 find_package(Boost REQUIRED COMPONENTS thread date_time filesystem system regex)
 


### PR DESCRIPTION
Modified `CMakeLists.txt` to make `Cmake` search for and find static Boost libraries in Windows that start with `lib` .
